### PR TITLE
`install_ceph_iscsi_from_packages` was being used instead of `install_lrbd`

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -82,7 +82,7 @@ Vagrant.configure("2") do |config|
     fi
 
     if #{install_lrbd}; then
-      /home/vagrant/bin/lrbd-provision.sh #{install_ceph_iscsi_from_packages}
+      /home/vagrant/bin/lrbd-provision.sh #{install_lrbd}
     fi
 
   SHELL


### PR DESCRIPTION
Signed-off-by: Ricardo Marques <rimarques@suse.com>